### PR TITLE
qs colors refactored

### DIFF
--- a/modules/quickshell/BottomSection.qml
+++ b/modules/quickshell/BottomSection.qml
@@ -11,6 +11,7 @@ import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
 import 'components' as Components
+import qs.configuration
 
 Rectangle {
   Layout.fillWidth: true
@@ -67,7 +68,7 @@ Rectangle {
 //      width: 24
 //      height: 40
 //      radius: 2
-//      color: "#111A1F"
+//      color: Colors.moduleBackground
 //
 //      ColumnLayout {
 //        anchors.centerIn: parent
@@ -76,7 +77,7 @@ Rectangle {
 //        Text {
 //          Layout.alignment: Qt.AlignHCenter
 //          text: currentHours
-//          color: "#C488EC"
+//          color: Colors.timeText
 //          font.family: "Cartograph CF Heavy"
 //          font.pixelSize: 11
 //        }
@@ -84,7 +85,7 @@ Rectangle {
 //        Text {
 //          Layout.alignment: Qt.AlignHCenter
 //          text: currentMinutes
-//          color: "#C488EC"
+//          color: Colors.timeText
 //          font.family: "Cartograph CF Heavy"
 //          font.pixelSize: 11
 //        }

--- a/modules/quickshell/TopSection.qml
+++ b/modules/quickshell/TopSection.qml
@@ -11,6 +11,7 @@ import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
 import 'components' as Components
+import qs.configuration
 
 Rectangle {
   Layout.fillWidth: true
@@ -95,7 +96,7 @@ Rectangle {
       height: 60
       radius: innerModulesRadius
 
-      color: (hoverHandler.hovered) ? "#1178B892" : "#111A1F"
+      color: (hoverHandler.hovered) ? Colors.moduleBackgroundHover : Colors.moduleBackground
 
       HoverHandler { id: hoverHandler }
       Behavior on border.color {
@@ -103,7 +104,7 @@ Rectangle {
       }
 
       border.width: 1
-      border.color: (hoverHandler.hovered) ? "#7778B892" : "#171F24"
+      border.color: (hoverHandler.hovered) ? Colors.moduleBorderHover : Colors.moduleBorder
 
       ColumnLayout {
         anchors.centerIn: parent
@@ -113,8 +114,8 @@ Rectangle {
         Components.RadialIndicator {
           Layout.alignment: Qt.AlignHCenter
           percent: cpuUsage
-          indicatorColor: "#DF5B61"
-          backgroundColor: "#333B3F"
+          indicatorColor: Colors.cpuIndicator
+          backgroundColor: Colors.indicatorBackground
           size: 24
         }
 
@@ -122,8 +123,8 @@ Rectangle {
         Components.RadialIndicator {
           Layout.alignment: Qt.AlignHCenter
           percent: ramUsage
-          indicatorColor: "#78B892"
-          backgroundColor: "#333B3F"
+          indicatorColor: Colors.ramIndicator
+          backgroundColor: Colors.indicatorBackground
           size: 24
         }
       }

--- a/modules/quickshell/components/BarBatteryInternet.qml
+++ b/modules/quickshell/components/BarBatteryInternet.qml
@@ -10,18 +10,19 @@ import Quickshell.Services.SystemTray
 import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
+import qs.configuration
 
 Rectangle {
   Layout.alignment: Qt.AlignHCenter
   width: 28
   height: 64
   radius: innerModulesRadius
-  color: (hoverHandler.hovered) ? "#1178B892" : "#111A1F"
+  color: (hoverHandler.hovered) ? Colors.moduleBackgroundHover : Colors.moduleBackground
 
   HoverHandler { id: hoverHandler }
 
   border.width: 1
-  border.color: (hoverHandler.hovered) ? "#7778B892" : "#171F24"
+  border.color: (hoverHandler.hovered) ? Colors.moduleBorderHover : Colors.moduleBorder
 
   Behavior on border.color {
     ColorAnimation { duration: 400 }
@@ -37,10 +38,9 @@ Rectangle {
       property real batteryLevel: 100
 
       function getBatteryColor(percent, color_type) {
-        //if (percent >= 50) return ((color_type == 'JUICE') ? "#9978B8a2" : "#78B8a2")
-        if (percent >= 50) return ((color_type == 'JUICE') ? "#9978B892" : "#78B892")
-        if (percent >= 30) return ((color_type == 'JUICE') ? "#99ECD28B" : "#ECD28B")
-        return ((color_type == 'JUICE') ? "#99DF5B61" : "#DF5B61")
+        if (percent >= 50) return ((color_type == 'JUICE') ? Colors.batteryHealthyJuice : Colors.batteryHealthy)
+        if (percent >= 30) return ((color_type == 'JUICE') ? Colors.batteryMediumJuice : Colors.batteryMedium)
+        return ((color_type == 'JUICE') ? Colors.batteryLowJuice : Colors.batteryLow)
       }
     }
 
@@ -88,7 +88,7 @@ Rectangle {
             width: 14
             height: 24
             radius: 4
-            color: "#041011"
+            color: Colors.batteryBackground
             border.color: batteryModule.getBatteryColor(batteryModule.batteryLevel, 'BORDER')
             border.width: 2
 

--- a/modules/quickshell/components/BarInternetStatus.qml
+++ b/modules/quickshell/components/BarInternetStatus.qml
@@ -10,13 +10,14 @@ import Quickshell.Services.SystemTray
 import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
+import qs.configuration
 
 Rectangle {
   Layout.alignment: Qt.AlignHCenter
   width: 28
   height: 28
   radius: innerModulesRadius
-  color: "#111A1F"
+  color: Colors.internetBackground
   
   property bool internetConnected: false
 

--- a/modules/quickshell/components/BarProfilePicture.qml
+++ b/modules/quickshell/components/BarProfilePicture.qml
@@ -10,6 +10,7 @@ import Quickshell.Services.SystemTray
 import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
+import qs.configuration
 
 Rectangle {
   Layout.alignment: Qt.AlignHCenter
@@ -18,7 +19,7 @@ Rectangle {
   width: 26//32
   height: 26//32
   radius: innerModulesRadius
-  color: "transparent"
+  color: Colors.moduleBackground
   clip: true
   //color: "#111A1F"
 

--- a/modules/quickshell/components/BarSystemTray.qml
+++ b/modules/quickshell/components/BarSystemTray.qml
@@ -10,6 +10,7 @@ import Quickshell.Services.SystemTray
 import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
+import qs.configuration
 
 Rectangle {
   Layout.alignment: Qt.AlignHCenter
@@ -17,12 +18,12 @@ Rectangle {
   visible: SystemTray.items.values.length
   width: 28
   radius: innerModulesRadius
-  color: (hoverHandler.hovered) ? "#11A9A9A9" : "#111A1F"
+  color: (hoverHandler.hovered) ? Colors.trayBackgroundHover : Colors.moduleBackground
 
   HoverHandler { id: hoverHandler }
 
   border.width: 1
-  border.color: (hoverHandler.hovered) ? "#77A9A9A9" : "#171F24"
+  border.color: (hoverHandler.hovered) ? Colors.trayBorderHover : Colors.moduleBorder
 
   Behavior on border.color {
     ColorAnimation { duration: 400 }

--- a/modules/quickshell/components/BarVolumeControl.qml
+++ b/modules/quickshell/components/BarVolumeControl.qml
@@ -10,18 +10,19 @@ import Quickshell.Services.SystemTray
 import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
+import qs.configuration
 
 Rectangle {
   Layout.alignment: Qt.AlignHCenter
   width: 28
   height: 78
   radius: innerModulesRadius
-  color: (hoverHandler.hovered) ? "#11BC83E3" : "#111A1F"
+  color: (hoverHandler.hovered) ? Colors.moduleBackgroundHover : Colors.moduleBackground
 
   HoverHandler { id: hoverHandler }
 
   border.width: 1
-  border.color: (hoverHandler.hovered) ? "#77BC83E3" : "#171F24"
+  border.color: (hoverHandler.hovered) ? Colors.moduleBorderHover : Colors.moduleBorder
 
   Behavior on border.color {
     ColorAnimation { duration: 400 }
@@ -111,7 +112,7 @@ Rectangle {
       Layout.bottomMargin: 4
       width: 8
       height: 46
-      color: "#333B3F"
+      color: Colors.volumeBarBackground
       radius: 1
 
       Rectangle {
@@ -125,8 +126,8 @@ Rectangle {
         radius: 1
         gradient: Gradient {
           orientation: Gradient.Vertical
-          GradientStop { position: 0; color: "#6791C9" }
-          GradientStop { position: 1; color: "#BC83E3" }
+          GradientStop { position: 0; color: Colors.volumeGradientStart }
+          GradientStop { position: 1; color: Colors.volumeGradientEnd }
         }
 
         Behavior on height {

--- a/modules/quickshell/components/BarVolumeControl.qml
+++ b/modules/quickshell/components/BarVolumeControl.qml
@@ -17,12 +17,12 @@ Rectangle {
   width: 28
   height: 78
   radius: innerModulesRadius
-  color: (hoverHandler.hovered) ? Colors.moduleBackgroundHover : Colors.moduleBackground
+  color: (hoverHandler.hovered) ? Colors.volumeBackgroundHover : Colors.moduleBackground
 
   HoverHandler { id: hoverHandler }
 
   border.width: 1
-  border.color: (hoverHandler.hovered) ? Colors.moduleBorderHover : Colors.moduleBorder
+  border.color: (hoverHandler.hovered) ? Colors.volumeBorderHover : Colors.moduleBorder
 
   Behavior on border.color {
     ColorAnimation { duration: 400 }

--- a/modules/quickshell/components/BarWeatherStatus.qml
+++ b/modules/quickshell/components/BarWeatherStatus.qml
@@ -10,16 +10,17 @@ import Quickshell.Services.SystemTray
 import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
+import qs.configuration
 
 Rectangle {
   Layout.alignment: Qt.AlignHCenter
   width: 28
   height: 48
-  color: (hoverHandler.hovered) ? "#226791C9" : "#111A1F"
+  color: (hoverHandler.hovered) ? Colors.weatherBackgroundHover : Colors.weatherBackground
   radius: innerModulesRadius
 
   border.width: 1
-  border.color: (hoverHandler.hovered) ? "#776791C9" : "#171F24"
+  border.color: (hoverHandler.hovered) ? Colors.weatherBorderHover : Colors.moduleBorder
 
   Behavior on border.color {
     ColorAnimation { duration: 400 }
@@ -71,7 +72,7 @@ Rectangle {
       Text {
         anchors.centerIn: parent
         text: `${temperature}°`
-        color: "#E9967E"
+        color: Colors.weatherTemperature
         font.family: "Cartograph CF Heavy Italic"
         font.pixelSize: 11
       }

--- a/modules/quickshell/components/HyprlandWorkspaces.qml
+++ b/modules/quickshell/components/HyprlandWorkspaces.qml
@@ -11,6 +11,7 @@ import Quickshell.Services.SystemTray
 import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
+import qs.configuration
 
 Rectangle {
   Layout.alignment: Qt.AlignHCenter
@@ -18,12 +19,12 @@ Rectangle {
   implicitHeight: childrenRect.height + 28
   width: 24
   radius: 2
-  color: (hoverHandler.hovered) ? "#11C0837F" : "#111A1F"
+  color: (hoverHandler.hovered) ? Colors.workspaceBackgroundHover : Colors.moduleBackground
 
   HoverHandler { id: hoverHandler }
 
   border.width: 1
-  border.color: (hoverHandler.hovered) ? "#77C0837F" : "#171F24"
+  border.color: (hoverHandler.hovered) ? Colors.workspaceBorderHover : Colors.moduleBorder
 
   Behavior on border.color {
     ColorAnimation { duration: 400 }
@@ -57,7 +58,7 @@ Rectangle {
             layer.samples: 8
 
             ShapePath {
-              fillColor: (modelData.active || parent.hovered) ? "#C0837F" : "#333B3F"
+              fillColor: (modelData.active || parent.hovered) ? Colors.workspaceActive : Colors.workspaceInactive
               strokeColor: "transparent"
               strokeWidth: 0
 

--- a/modules/quickshell/components/Player.qml
+++ b/modules/quickshell/components/Player.qml
@@ -10,6 +10,7 @@ import Quickshell.Services.SystemTray
 import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
+import qs.configuration
 
 Rectangle {
   id: playerModule
@@ -18,12 +19,12 @@ Rectangle {
   layer.enabled: true
   width: 28
   radius: innerModulesRadius
-  color: "#111A1F"
+  color: Colors.moduleBackground
 
   HoverHandler { id: hoverHandler }
 
   border.width: 1
-  border.color: (hoverHandler.hovered && !playing) ? "#77BC83E3" : "#111A1F"
+  border.color: (hoverHandler.hovered && !playing) ? Colors.playerBorderHover : Colors.moduleBackground
 
   Behavior on border.color {
     ColorAnimation { duration: 200 }
@@ -117,8 +118,8 @@ Rectangle {
     }
 
     gradient: Gradient {
-      GradientStop { position: 0.6; color: "#171F24" }
-      GradientStop { position: 1.0; color: "#66BC83E3" }
+      GradientStop { position: 0.6; color: Colors.playerGradientStart }
+      GradientStop { position: 1.0; color: Colors.playerGradientEnd }
     }
 
     Rectangle {

--- a/modules/quickshell/components/PopoutVolume.qml
+++ b/modules/quickshell/components/PopoutVolume.qml
@@ -4,6 +4,7 @@ import Quickshell
 import Quickshell.Services.Pipewire
 import Quickshell.Widgets
 import Quickshell.Io
+import qs.configuration
 
 Scope {
   id: root
@@ -119,10 +120,10 @@ Scope {
         id: mainRect
         anchors.fill: parent
         radius: 4
-        color: "#111A1F"
+        color: Colors.popoutBackground
 
         border.width: 3
-        border.color: "#171F24"
+        border.color: Colors.popoutBorder
 
         property real yOffset: 0
 
@@ -206,7 +207,7 @@ Scope {
           }
 
           Rectangle {
-            color: "#333B3F"
+            color: Colors.volumeBarBackground
             Layout.fillWidth: true
             implicitHeight: 10
             radius: 2
@@ -220,8 +221,8 @@ Scope {
               }
               gradient: Gradient {
                 orientation: Gradient.Horizontal
-                GradientStop { position: 0; color: "#6791C9" }
-                GradientStop { position: 1; color: "#BC83E3" }
+                GradientStop { position: 0; color: Colors.volumeGradientStart }
+                GradientStop { position: 1; color: Colors.volumeGradientEnd }
               }
 
               width: {

--- a/modules/quickshell/components/PopoutVolume.qml
+++ b/modules/quickshell/components/PopoutVolume.qml
@@ -94,6 +94,7 @@ Scope {
     active: root.shouldShowOsd
 
     PanelWindow {
+      exclusionMode: ExclusionMode.Ignore
       anchors.bottom: true
       margins.bottom: screen.height / 12
 

--- a/modules/quickshell/components/Power.qml
+++ b/modules/quickshell/components/Power.qml
@@ -10,6 +10,7 @@ import Quickshell.Services.SystemTray
 import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
+import qs.configuration
 
 Rectangle {
   Layout.alignment: Qt.AlignHCenter
@@ -17,10 +18,10 @@ Rectangle {
   height: 28
   width: 28
   radius: innerModulesRadius
-  color: hoverHandler.hovered ? "#28DF5B61" : "#1D1A20"
+  color: hoverHandler.hovered ? Colors.powerBackgroundHover : Colors.powerBackground
 
   border.width: 1
-  border.color: hoverHandler.hovered ? "#77DF5B61" : "#171F24"
+  border.color: hoverHandler.hovered ? Colors.powerBorderHover : Colors.powerBorder
 
   HoverHandler { id: hoverHandler }
 

--- a/modules/quickshell/configuration/Colors.qml
+++ b/modules/quickshell/configuration/Colors.qml
@@ -1,0 +1,66 @@
+pragma Singleton
+import QtQuick
+
+QtObject {
+    readonly property color barBackground: "#000A0E"
+    readonly property color barBorder: "#111A1F"
+    
+    readonly property color moduleBackground: "#111A1F"
+    readonly property color moduleBackgroundHover: "#1178B892"
+    readonly property color moduleBorder: "#171F24"
+    readonly property color moduleBorderHover: "#7778B892"
+    
+    readonly property color cpuIndicator: "#DF5B61"
+    readonly property color ramIndicator: "#78B892"
+    readonly property color indicatorBackground: "#333B3F"
+    
+    readonly property color timeText: "#C488EC"
+
+    // Player colors
+    readonly property color playerBorderHover: "#77BC83E3"
+    readonly property color playerGradientStart: "#171F24"
+    readonly property color playerGradientEnd: "#66BC83E3"
+    
+    // Volume colors
+    readonly property color volumeBarBackground: "#333B3F"
+    readonly property color volumeGradientStart: "#6791C9"
+    readonly property color volumeGradientEnd: "#BC83E3"
+    
+    // Weather colors
+    readonly property color weatherBackground: "#111A1F"
+    readonly property color weatherBackgroundHover: "#226791C9"
+    readonly property color weatherBorderHover: "#776791C9"
+    readonly property color weatherTemperature: "#E9967E"
+    
+    // Internet status colors
+    readonly property color internetBackground: "#111A1F"
+    
+    // System tray colors
+    readonly property color trayBackgroundHover: "#11A9A9A9"
+    readonly property color trayBorderHover: "#77A9A9A9"
+    
+    // Workspace colors
+    readonly property color workspaceBackgroundHover: "#11C0837F"
+    readonly property color workspaceBorderHover: "#77C0837F"
+    readonly property color workspaceActive: "#C0837F"
+    readonly property color workspaceInactive: "#333B3F"
+
+    // Power button colors
+    readonly property color powerBackground: "#1D1A20"
+    readonly property color powerBackgroundHover: "#28DF5B61"
+    readonly property color powerBorder: "#171F24"
+    readonly property color powerBorderHover: "#77DF5B61"
+    
+    // Battery colors
+    readonly property color batteryBackground: "#041011"
+    readonly property color batteryHealthy: "#78B892"
+    readonly property color batteryMedium: "#ECD28B"
+    readonly property color batteryLow: "#DF5B61"
+    readonly property color batteryHealthyJuice: "#9978B892"
+    readonly property color batteryMediumJuice: "#99ECD28B"
+    readonly property color batteryLowJuice: "#99DF5B61"
+    
+    // Popout colors
+    readonly property color popoutBackground: "#111A1F"
+    readonly property color popoutBorder: "#171F24"
+}

--- a/modules/quickshell/configuration/Colors.qml
+++ b/modules/quickshell/configuration/Colors.qml
@@ -22,6 +22,8 @@ QtObject {
     readonly property color playerGradientEnd: "#66BC83E3"
     
     // Volume colors
+    readonly property color volumeBorderHover: "#77BC83E3"
+    readonly property color volumeBackgroundHover: "#11BC83E3"
     readonly property color volumeBarBackground: "#333B3F"
     readonly property color volumeGradientStart: "#6791C9"
     readonly property color volumeGradientEnd: "#BC83E3"

--- a/modules/quickshell/shell.qml
+++ b/modules/quickshell/shell.qml
@@ -12,6 +12,7 @@ import Quickshell.Services.Pipewire
 import Quickshell.Services.Mpris
 import Qt5Compat.GraphicalEffects
 import 'components' as Components
+import qs.configuration
 
 Scope {
   id: root
@@ -47,11 +48,11 @@ Scope {
     // The actual bar - Extra rect to achieve bar-rounding
     Rectangle {
       anchors.fill: parent
-      color: "#000A0E"
+      color: Colors.barBackground
       radius: 4
 
       border.width: 2
-      border.color: "#111A1F"
+      border.color: Colors.barBorder
 
       Behavior on height {
         NumberAnimation {


### PR DESCRIPTION
made the colors in Colors.qml very separated to allow changes to specific modules rather than the overall conf. 

Colors.qml is inside /configuration, which could later include another .qml file in case you wanna centralize other stuff (like border-width, bar size, etc)

PS: update quickshell, the import syntax changed a bit..